### PR TITLE
[test, refactor] initとclientのテストとリファクタリング

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,8 @@
+# デフォルトの無視対象ファイル
+/shelf/
+/workspace.xml
+# エディターベースの HTTP クライアントリクエスト
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/rabbit.iml" filepath="$PROJECT_DIR$/.idea/rabbit.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/rabbit.iml
+++ b/.idea/rabbit.iml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="WEB_MODULE" version="4">
+  <component name="Go" enabled="true" />
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/lib/client.go
+++ b/lib/client.go
@@ -1,14 +1,11 @@
 package lib
 
-import "os"
-
-func CreateClient() Client {
-	curent_dir, _ := os.Getwd()
+func CreateClient(currentDir string) Client {
 	return Client{
-		WorkPath:  curent_dir,
-		RepoPath:  curent_dir + "/.rabbit",
-		IndexPath: curent_dir + "/.rabbit/index",
-		HeadPath:  curent_dir + "/.rabbit/HEAD",
+		WorkPath:  currentDir,
+		RepoPath:  currentDir + "/.rabbit",
+		IndexPath: currentDir + "/.rabbit/index",
+		HeadPath:  currentDir + "/.rabbit/HEAD",
 	}
 }
 

--- a/lib/client_test.go
+++ b/lib/client_test.go
@@ -1,14 +1,39 @@
 package lib
 
 import (
+	"os"
 	"testing"
 )
 
 func TestClient(t *testing.T) {
-	client := CreateClient()
+	currentDir, _ := os.Getwd()
+	client := CreateClient(currentDir)
 
-	if client.WorkPath != "/home/aoimaru/document/go_project/CLI/rabbit/lib" {
-		t.Errorf("Unexpected WorkPath value: %s", client.WorkPath)
+	t.Run("local path", func(t *testing.T) {
+		want := "/Users/haradakanon/Desktop/rabbit/lib"
+		assertLocalPath(t, client, want)
+	})
+
+	t.Run("local repository", func(t *testing.T) {
+		want := "/Users/haradakanon/Desktop/rabbit/lib/.rabbit"
+		assertLocalRepo(t, client, want)
+	})
+}
+
+// assertLocalPath は実行者のローカルPCの絶対パスと一致しているかチェックする.
+func assertLocalPath(t *testing.T, got Client, want string) {
+	t.Helper()
+
+	if got.GetWorkPath() != want {
+		t.Errorf("Unexpected WorkPath value: %s", got.WorkPath)
 	}
+}
 
+// assertLocalRepo は実行者のローカルPCの絶対パスと一致しているかチェックする.
+func assertLocalRepo(t *testing.T, got Client, want string) {
+	t.Helper()
+
+	if got.GetRepoPath() != want {
+		t.Errorf("Unexpected WorkPath value: %s", got.RepoPath)
+	}
 }

--- a/lib/init.go
+++ b/lib/init.go
@@ -8,24 +8,22 @@ func (c *Client) Init() error {
 	if _, err := os.Stat(c.RepoPath); err == nil {
 		_ = os.RemoveAll(c.RepoPath)
 	}
-	if err := os.MkdirAll(c.RepoPath, os.ModePerm); err != nil {
-		return err
+
+	// init時に生成するファイル名の配列.
+	initArray := []string{"", "/objects", "/refs", "/refs/heads"}
+	for _, value := range initArray {
+		err := CreateDir(c.RepoPath + value)
+		if err != nil {
+			return err
+		}
 	}
 
-	if err := os.MkdirAll(c.RepoPath+"/objects", os.ModePerm); err != nil {
-		return err
-	}
-	if err := os.MkdirAll(c.RepoPath+"/refs", os.ModePerm); err != nil {
-		return err
-	}
-	if err := os.MkdirAll(c.RepoPath+"/refs/heads", os.ModePerm); err != nil {
-		return err
-	}
-	init_head_buffer := []byte("ref: refs/heads/master\n")
-	_, _ = CreateFile(c.HeadPath, init_head_buffer)
+	// TODO ここもまとめますか?
+	initHeadBuffer := []byte("ref: refs/heads/main\n")
+	_, _ = CreateFile(c.HeadPath, initHeadBuffer)
 
-	init_refs_heads_master_buffer := []byte("")
-	_, _ = CreateFile(c.RepoPath+"/refs/heads/master", init_refs_heads_master_buffer)
+	initRefsHeadsMainBuffer := []byte("")
+	_, _ = CreateFile(c.RepoPath+"/refs/heads/main", initRefsHeadsMainBuffer)
 
 	return nil
 }

--- a/lib/init_test.go
+++ b/lib/init_test.go
@@ -1,1 +1,69 @@
 package lib
+
+import (
+	"log"
+	"os"
+	"testing"
+)
+
+func TestInit(t *testing.T) {
+	currentDir := "/Users/haradakanon/Desktop/Stub"
+	client := CreateClient(currentDir)
+
+	err := client.Init()
+	if err != nil {
+		t.Error("Failed to init")
+	}
+
+	t.Run(".rabbit dir", func(t *testing.T) {
+		path := "/Users/haradakanon/Desktop/Stub/.rabbit"
+		assertDir(t, path)
+	})
+
+	t.Run("/objects dir", func(t *testing.T) {
+		path := "/Users/haradakanon/Desktop/Stub/.rabbit/objects"
+		assertDir(t, path)
+	})
+
+	t.Run("/refs dir", func(t *testing.T) {
+		path := "/Users/haradakanon/Desktop/Stub/.rabbit/refs"
+		assertDir(t, path)
+	})
+
+	t.Run("/refs/heads dir", func(t *testing.T) {
+		path := "/Users/haradakanon/Desktop/Stub/.rabbit/refs/heads"
+		assertDir(t, path)
+	})
+
+	t.Run("HEAD file", func(t *testing.T) {
+		path := "/Users/haradakanon/Desktop/Stub/.rabbit/HEAD"
+		want := "ref: refs/heads/main\n"
+		assertFileContents(t, path, want)
+	})
+
+	t.Run("/refs/heads/main file", func(t *testing.T) {
+		path := "/Users/haradakanon/Desktop/Stub/.rabbit/refs/heads/main"
+		want := ""
+		assertFileContents(t, path, want)
+	})
+}
+
+// assertDir はディレクトリの存在をチェックする.
+func assertDir(t *testing.T, path string) {
+	if _, err := os.Stat(path); err != nil {
+		t.Errorf("The directory does not exist: %s", path)
+	}
+}
+
+// assertFileContents はファイルの中身をチェックする.
+func assertFileContents(t *testing.T, path, want string) {
+	contents, err := os.ReadFile(path)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	got := string(contents)
+	if got != want {
+		t.Errorf("contents %s want %s", got, want)
+	}
+}


### PR DESCRIPTION
# initとclientのテストとリファクタリング
## initとclientのテストを作成しました。
- カバー率はinitが91%でclientは100%です。
- nit時のファイル生成の失敗ケースのテスト手法が浮かばなかったので実装していません。(何かいい方法あります？)

## initとclientのリファクタリングを行いました。
- テストの振る舞いは変わっていないので大丈夫とは思いますが、チェックお願いします。
- 変数名やファイル生成の方法など変えてみました。

レビューお願いします。